### PR TITLE
chore: default to starknet.js v4

### DIFF
--- a/.changeset/calm-beers-give.md
+++ b/.changeset/calm-beers-give.md
@@ -1,0 +1,7 @@
+---
+"get-starknet-core": minor
+"get-starknet": minor
+"get-starknet-example": minor
+---
+
+Default to starknet.js v4 and add future compatiblity to v5

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ interface GetStarknetResult {
   enable: (
     wallet: StarknetWindowObject,
     options?: {
-      starknetVersion?: "v3" | "v4"
+      starknetVersion?: "v4" | "v5"
     },
   ) => Promise<ConnectedStarknetWindowObject>
   // Disconnects from a wallet

--- a/packages/core/src/StarknetWindowObject.ts
+++ b/packages/core/src/StarknetWindowObject.ts
@@ -76,7 +76,7 @@ export interface IStarknetWindowObject {
   request: <T extends RpcMessage>(
     call: Omit<T, "result">,
   ) => Promise<T["result"]>
-  enable: (options?: { starknetVersion?: "v3" | "v4" }) => Promise<string[]>
+  enable: (options?: { starknetVersion?: "v4" | "v5" }) => Promise<string[]>
   isPreauthorized: () => Promise<boolean>
   on: <E extends WalletEvents>(
     event: E["type"],

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -60,7 +60,7 @@ interface GetStarknetResult {
   enable: (
     wallet: StarknetWindowObject,
     options?: {
-      starknetVersion?: "v3" | "v4"
+      starknetVersion?: "v4" | "v5"
     },
   ) => Promise<ConnectedStarknetWindowObject> // Connects to a wallet
   disconnect: (options?: DisconnectOptions) => Promise<void> // Disconnects from a wallet
@@ -121,7 +121,7 @@ export function getStarknet(
       return firstPreAuthorizedWallet
     },
     enable: async (wallet, options) => {
-      await wallet.enable(options)
+      await wallet.enable(options ?? { starknetVersion: "v4" })
       if (!wallet.isConnected) {
         throw new Error("Failed to connect to wallet")
       }


### PR DESCRIPTION
Following starknet.js weekly call it was decided to default to v4 (as current default on wallets side is v3) - this should be released after the community was informed via Twitter and other channels