### PR TITLE
chore: bump starknet.js to use latest stable

### DIFF
--- a/.changeset/purple-rivers-nail.md
+++ b/.changeset/purple-rivers-nail.md
@@ -1,0 +1,5 @@
+---
+"get-starknet-core": minor
+---
+
+use latest stable starknet.js v5

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "c8": "^7.12.0",
     "happy-dom": "^6.0.4",
-    "starknet": "^5.12.0",
+    "starknet": "^5.14.1",
     "starknet4": "npm:starknet@4.22.0",
     "typescript": "^4.6.4",
     "vite": "^3.0.0",
@@ -40,7 +40,7 @@
     "vitest": "^0.19.1"
   },
   "peerDependencies": {
-    "starknet": "^5.0.0"
+    "starknet": "^5.14.1"
   },
   "peerDependenciesMeta": {
     "starknet": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^6.0.4
         version: 6.0.4
       starknet:
-        specifier: ^5.12.0
-        version: 5.12.0
+        specifier: ^5.14.1
+        version: 5.14.1
       starknet4:
         specifier: npm:starknet@4.22.0
         version: /starknet@4.22.0
@@ -4506,8 +4506,8 @@ packages:
       - encoding
     dev: true
 
-  /starknet@5.12.0:
-    resolution: {integrity: sha512-GKx+RdwOfk9rK/lJMQhQmjbc5BIhzX1kOA3HX21uRuu6UXovgWpTOgUzZXKGyRDA9SS4lAsMoLK99ARpC0bUww==}
+  /starknet@5.14.1:
+    resolution: {integrity: sha512-EtJwQ6RmFsqSLGuMP+PRp4DwNsMYXy63HDnd1plLCdQKl3FMYajqNKf5RbDl03uGU0uE5ctGp+OW3firHuv6IA==}
     dependencies:
       '@noble/curves': 1.0.0
       isomorphic-fetch: 3.0.0


### PR DESCRIPTION
Use starknet.js v5.14.1 which is the latest stable and supports jsonrpc spec v0.3.0