### PR TITLE
Improvements of core exports

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -20,7 +20,6 @@ export type {
   AddInvokeTransactionResult,
   AddStarknetChainParameters,
   RequestAccountsParameters,
-  StarknetChainId,
   SwitchStarknetChainParameters,
   GetDeploymentDataResult,
   WatchAssetParameters,
@@ -39,7 +38,10 @@ export type {
   WalletEventHandlers,
 } from "./walletEvents"
 
-export { Permission } from "./rpcMessage"
+export { StarknetChainId, Permission } from "./rpcMessage"
+
+export { scanObjectForWallets } from "./wallet/scan"
+export { isWalletObj } from "./wallet/isWalletObject"
 
 export type {
   DisconnectOptions,


### PR DESCRIPTION
@dhruvkelawala 
(info : @ivpavici )

1. In `core`, `StarknetChainId` and `Permission` are enums.
`Permission` is exported as enum, but `StarknetChainId` is exported as type.
To be able to use correctly `StarknetChainId`, it's proposed to export it also as an enum.
2. During tests of Starknet.js `WalletAccount` class in a DAPP, it appeared that it's beneficial for DAPP devs to be able to import  `scanObjectForWallets` & `isWalletObj`. It's proposed to add these 2 exports in core.
