### PR TITLE
Feature/add development mode to use local served remoteEntry.js

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prod": "vite"
   },
   "dependencies": {
     "get-starknet": "workspace:^3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "format": "prettier --ignore-path .gitignore --plugin-search-dir=. --write '**/*.{js,cjs,ts,tsx,svelte,md,yml,json}'",
     "format:check": "prettier --ignore-path .gitignore --plugin-search-dir=. --check '**/*.{js,cjs,ts,tsx,svelte,md,yml,json}'",
     "prepare": "pnpm run build && husky install",
+    "prod": "pnpm run -r --parallel prod",
     "publish": "pnpm publish -r --no-git-checks",
     "test": "CI=true pnpm run -r test",
     "version": "changeset version && pnpm install --lockfile-only"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,12 +25,14 @@
     "dist"
   ],
   "scripts": {
-    "build": "vite build",
-    "dev": "vite build --watch",
+    "build": "vite build --mode production",
+    "dev": "vite build --watch --mode development",
+    "prod": "vite build --watch --mode production",
     "test": "vitest"
   },
   "dependencies": {
-    "@module-federation/runtime": "^0.1.2"
+    "@module-federation/runtime": "^0.1.2",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "c8": "^7.12.0",

--- a/packages/core/src/wallet/metamaskBridge.ts
+++ b/packages/core/src/wallet/metamaskBridge.ts
@@ -7,6 +7,13 @@ import type {
 import wallets, { WalletProvider } from "../discovery"
 import { init, loadRemote } from "@module-federation/runtime"
 
+const remoteEntryUrl =
+  import.meta.env.MODE === "development"
+    ? "http://localhost:8082/remoteEntry.js"
+    : "https://snaps.consensys.io/starknet/get-starknet/v1/remoteEntry.js"
+
+console.log(remoteEntryUrl)
+
 interface MetaMaskProvider {
   isMetaMask: boolean
   request(options: { method: string }): Promise<void>
@@ -130,8 +137,7 @@ function createMetaMaskProviderWrapper(
             {
               name: "MetaMaskStarknetSnapWallet",
               alias: "MetaMaskStarknetSnapWallet",
-              entry:
-                "https://snaps.consensys.io/starknet/get-starknet/v1/remoteEntry.js",
+              entry: remoteEntryUrl,
             },
           ],
         })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "dev": "vite build --watch"
+    "dev": "vite build --watch",
+    "prod": "vite build --watch"
   },
   "dependencies": {
     "bowser": "^2.11.0",


### PR DESCRIPTION
In order to facilitate local testing of get-starknet we add the capability of loading the remoteEntry.js from localhost:8082 when doing `pnpm run dev`. The original behaviour is kept when doing `pnpm run prod`. 