### PR TITLE
fix: Decouple Virtual Wallet Discovery in `get-starknet`

### DIFF
--- a/.changeset/eleven-buttons-unite.md
+++ b/.changeset/eleven-buttons-unite.md
@@ -1,0 +1,5 @@
+---
+"@starknet-io/get-starknet-core": patch
+---
+
+Decouple Virtual Wallet Discovery for async workflow

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -117,13 +117,15 @@ export function getStarknet(
 
       return firstAuthorizedWallet
     },
-    discoverVirtualWallets: async () => {
-      virtualWallets.forEach(async (virtualWallet) => {
-        const hasSupport = await virtualWallet.hasSupport(windowObject)
-        if (hasSupport) {
-          windowObject[virtualWallet.windowKey] = virtualWallet
-        }
-      })
+    discoverVirtualWallets: async (): Promise<void> => {
+      await Promise.all(
+        virtualWallets.map(async (virtualWallet) => {
+          const hasSupport = await virtualWallet.hasSupport(windowObject)
+          if (hasSupport) {
+            windowObject[virtualWallet.windowKey] = virtualWallet
+          }
+        }),
+      )
     },
     enable: async (inputWallet, options) => {
       let wallet: StarknetWindowObject

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -117,9 +117,22 @@ export function getStarknet(
 
       return firstAuthorizedWallet
     },
-    discoverVirtualWallets: async (): Promise<void> => {
+    discoverVirtualWallets: async (
+      walletNamesOrIds: string[] = [],
+    ): Promise<void> => {
+      const walletNamesOrIdsSet = new Set(walletNamesOrIds)
+
+      const virtualWalletToDiscover =
+        walletNamesOrIdsSet.size > 0
+          ? virtualWallets.filter(
+              (virtualWallet) =>
+                walletNamesOrIdsSet.has(virtualWallet.name) ||
+                walletNamesOrIdsSet.has(virtualWallet.id),
+            )
+          : virtualWallets
+
       await Promise.all(
-        virtualWallets.map(async (virtualWallet) => {
+        virtualWalletToDiscover.map(async (virtualWallet) => {
           const hasSupport = await virtualWallet.hasSupport(windowObject)
           if (hasSupport) {
             windowObject[virtualWallet.windowKey] = virtualWallet

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -13,6 +13,7 @@ import { sortBy } from "./wallet/sort"
 import {
   initiateVirtualWallets,
   resolveVirtualWallet,
+  virtualWallets,
 } from "./wallet/virtualWallets"
 import { Permission, type StarknetWindowObject } from "@starknet-io/types-js"
 
@@ -115,6 +116,14 @@ export function getStarknet(
       }
 
       return firstAuthorizedWallet
+    },
+    discoverVirtualWallets: async () => {
+      virtualWallets.forEach(async (virtualWallet) => {
+        const hasSupport = await virtualWallet.hasSupport(windowObject)
+        if (hasSupport) {
+          windowObject[virtualWallet.windowKey] = virtualWallet
+        }
+      })
     },
     enable: async (inputWallet, options) => {
       let wallet: StarknetWindowObject

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -69,6 +69,7 @@ export interface GetStarknetResult {
   ) => Promise<StarknetWindowObject[]> // Returns only preauthorized wallets available in the window object
   getDiscoveryWallets: (options?: GetWalletOptions) => Promise<WalletProvider[]> // Returns all wallets in existence (from discovery file)
   getLastConnectedWallet: () => Promise<StarknetWindowObject | null | undefined> // Returns the last wallet connected when it's still connected
+  discoverVirtualWallets: () => Promise<void> // Discovers the virtual wallets by calling their hasSupport methods
   enable: (
     wallet: StarknetWindowObject | VirtualWallet,
     options?: RequestAccountsParameters,

--- a/packages/core/src/wallet/virtualWallets/index.ts
+++ b/packages/core/src/wallet/virtualWallets/index.ts
@@ -6,9 +6,11 @@ const virtualWallets: VirtualWallet[] = [metaMaskVirtualWallet]
 
 function initiateVirtualWallets(windowObject: Record<string, unknown>) {
   virtualWallets.forEach(async (virtualWallet) => {
-    const hasSupport = await virtualWallet.hasSupport(windowObject)
-    if (hasSupport) {
-      windowObject[virtualWallet.windowKey] = virtualWallet
+    if (!(virtualWallet.windowKey in windowObject)) {
+      const hasSupport = await virtualWallet.hasSupport(windowObject)
+      if (hasSupport) {
+        windowObject[virtualWallet.windowKey] = virtualWallet
+      }
     }
   })
 }
@@ -28,4 +30,4 @@ async function resolveVirtualWallet(
   return wallet
 }
 
-export { initiateVirtualWallets, resolveVirtualWallet }
+export { initiateVirtualWallets, resolveVirtualWallet, virtualWallets }


### PR DESCRIPTION
# Decouple Virtual Wallet Discovery in `get-starknet`

## Summary
This PR introduces a `discoverVirtualWallets` method to handle virtual wallet discovery asynchronously, decoupling it from the synchronous `GetStarknet()` function. 

## Changes
- Added `discoverVirtualWallets` for explicit async virtual wallet discovery.
- Refactored `initiateVirtualWallets` to avoid redundant `hasSupport` calls.

## Why
Users can still call `GetStarknet()` with the current fire-and-forget behavior. However, this change allows developers to ensure the async discovery process is completed before calling `GetStarknet()` synchronously, giving more control over the workflow.