### PR TITLE
feat: add MetaMask event subscription support

### DIFF
--- a/.changeset/long-kangaroos-talk.md
+++ b/.changeset/long-kangaroos-talk.md
@@ -1,0 +1,6 @@
+---
+"@starknet-io/get-starknet-core": patch
+---
+
+refactor MetaMask Virtual Wallet to improve event handling, RPC requests, and
+wallet initialization logic

--- a/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
+++ b/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
@@ -117,8 +117,7 @@ class MetaMaskVirtualWallet
   async loadWallet(
     windowObject: Record<string, unknown>,
   ): Promise<StarknetWindowObject> {
-    // Using `this.#loadSwoSafe` to prevent the wallet is loading in a racing condition
-
+    // Using `this.#loadSwoSafe` to prevent the wallet is loading in a racing condition.
     await this.#loadSwoSafe(windowObject)
     // Whenever trgger function call to  `request` / `on` / `off`,
     // it will load the wallet into the `this.swo` object and forward the function call to the `this.swo` object.

--- a/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
+++ b/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
@@ -117,12 +117,13 @@ class MetaMaskVirtualWallet
   async loadWallet(
     windowObject: Record<string, unknown>,
   ): Promise<StarknetWindowObject> {
-    // Using `this.#loadSwoSafe` to prevent the wallet is loading in a racing condition.
+    // Using `this.#loadSwoSafe` to prevent race condition when the wallet is loading.
     await this.#loadSwoSafe(windowObject)
-    // Whenever trgger function call to  `request` / `on` / `off`,
-    // it will load the wallet into the `this.swo` object and forward the function call to the `this.swo` object.
-    // Therefore the `MetaMaskVirtualWallet` object actually act as a proxy to the `this.swo` object.
-    // Thus, to standardize the behavior, we should return the `MetaMaskVirtualWallet` object here, instead of the `this.swo` object.
+    // The `MetaMaskVirtualWallet` object acts as a proxy for the `this.swo` object.
+    // When `request`, `on`, or `off` is called, the wallet is loaded into `this.swo`,
+    // and the function call is forwarded to it.
+    // To maintain consistent behaviour, the `MetaMaskVirtualWallet`
+    // object (`this`) is returned instead of `this.swo`.
     return this
   }
 
@@ -171,10 +172,10 @@ class MetaMaskVirtualWallet
   }
 
   /**
-   * Verify if the hosting machine is support the Wallet or not without loading the wallet itself.
+   * Verify if the hosting machine supports the Wallet or not without loading the wallet itself.
    *
    * @param windowObject The window object.
-   * @returns A promise to resolve a boolean value to indicate the support status.
+   * @returns A promise that resolves to a boolean value to indicate the support status.
    */
   async hasSupport(windowObject: Record<string, unknown>) {
     this.provider = await detectMetamaskSupport(windowObject)
@@ -236,7 +237,7 @@ class MetaMaskVirtualWallet
 
   /**
    * Load the `StarknetWindowObject` safely with lock.
-   * And prevent the loading operation fall into a racing condirtion.
+   * And prevent the loading operation fall into a racing condition.
    *
    * @returns A promise to resolve a `StarknetWindowObject`.
    */

--- a/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
+++ b/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
@@ -146,8 +146,7 @@ class MetaMaskVirtualWallet
         {
           name: "MetaMaskStarknetSnapWallet",
           alias: "MetaMaskStarknetSnapWallet",
-          entry:
-            "https://snaps.consensys.io/starknet/get-starknet/v1/remoteEntry.js",
+          entry: `https://snaps.consensys.io/starknet/get-starknet/v1/remoteEntry.js?ts=${Date.now()}`,
         },
       ],
     })

--- a/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
+++ b/packages/core/src/wallet/virtualWallets/metaMaskVirtualWallet.ts
@@ -193,7 +193,7 @@ class MetaMaskVirtualWallet
   ): Promise<Data["result"]> {
     return this.#loadSwoSafe().then((swo: StarknetWindowObject) => {
       // Forward the request to the `this.swo` object.
-      // Except RPC `wallet_supportedSpecs` and `wallet_getPermissions`, others API will trigger the Snap to install if not installed
+      // Except RPCs `wallet_supportedSpecs` and `wallet_getPermissions`, other RPCs will trigger the Snap to install if not installed.
       return swo.request(
         call as unknown as RequestFnCall<Data["type"]>,
       ) as unknown as Data["result"]


### PR DESCRIPTION
This PR is to adding the on and off event support into the MetaMask Virtual Wallet

The change includes:

- add code comment
- add on and off support
- remove the hardcode response for `wallet_supportedSpecs` and `wallet_getPermissions`, as it can be return directly from the actual wallet
- To sync the behaviour of `discoverVirtualWallets` (it returns the VirtualWallet itself), update `loadWallet` method to return the virtual wallet, rather than the `swo`, as the `swo` has already binded into the virtual wallet